### PR TITLE
Update powerdns-mysql-slave-zones-add.php

### DIFF
--- a/powerdns-mysql-slave-zones-add/powerdns-mysql-slave-zones-add.php
+++ b/powerdns-mysql-slave-zones-add/powerdns-mysql-slave-zones-add.php
@@ -47,7 +47,7 @@ if (isset($login['status']) && $login['status'] == 'Failed') {
 }
 
 // check db connection
-$db = mysqli_connect(PDNS_MYSQL_HOST, PDNS_MYSQL_USER, PDNS_MYSQL_PASS, PDNS_MYSQL_PORT);
+$db = mysqli_connect(PDNS_MYSQL_HOST, PDNS_MYSQL_USER, PDNS_MYSQL_PASS, PDNS_MYSQL_DB, PDNS_MYSQL_PORT);
 if (!$db) {
 	die("Unable to connect to the database.\n");
 }


### PR DESCRIPTION
Incorrect use of mysqli_connect function:
PHP Warning:  mysqli_connect(): (HY000/1044): Access denied for user PDNS_MYSQL_USER@PDNS_MYSQL_HOST to database PDNS_MYSQL_PORT in powerdns-mysql-slave-zones-add.php on line 50
Unable to connect to the database.